### PR TITLE
Make patches more concise by diffing json objects

### DIFF
--- a/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
+++ b/src/RedArrow.Argo.Client.Integration/Session/CrudTests.cs
@@ -72,6 +72,7 @@ namespace RedArrow.Argo.Client.Integration.Session
             var updatedLastName = "Bull";
             var updatedPhone = "+10987654321";
             var updatedExtension = "1234";
+            var initialPhoneType = "Home";
 
             Guid crossSessionId;
 
@@ -83,7 +84,8 @@ namespace RedArrow.Argo.Client.Integration.Session
                     LastName = initialLastName,
                     Phone = new Phone
                     {
-                        Number = initialPhone
+                        Number = initialPhone,
+                        Type = initialPhoneType
                     }
                 };
 
@@ -97,6 +99,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(initialFirstName, patient.FirstName);
                 Assert.Equal(initialLastName, patient.LastName);
                 Assert.Equal(initialPhone, patient.Phone.Number);
+                Assert.Equal(initialPhoneType, patient.Phone.Type);
 
                 crossSessionId = patient.Id;
 
@@ -128,6 +131,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(updatedLastName, patient.LastName);
                 Assert.Equal(updatedPhone, patient.Phone.Number);
                 Assert.Equal(updatedExtension, patient.Phone.Extension);
+                Assert.Equal(initialPhoneType, patient.Phone.Type);
                 // The Update call should also mutate the passed in model with new Meta or attributes
                 Assert.NotEqual(oldUpdatedAt, patient.UpdatedAt);
                 Assert.NotEqual(oldEtag, patient.Etag);
@@ -137,6 +141,9 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(patient.Id, patient2.Id);
                 Assert.Equal(patient.FirstName, patient2.FirstName);
                 Assert.Equal(patient.LastName, patient2.LastName);
+                Assert.Equal(patient.Phone.Number, patient2.Phone.Number);
+                Assert.Equal(patient.Phone.Extension, patient2.Phone.Extension);
+                Assert.Equal(patient.Phone.Type, patient2.Phone.Type);
             }
             // later that day...
             using (var session = SessionFactory.CreateSession())
@@ -148,6 +155,7 @@ namespace RedArrow.Argo.Client.Integration.Session
                 Assert.Equal(updatedLastName, patient.LastName);
                 Assert.Equal(updatedPhone, patient.Phone.Number);
                 Assert.Equal(updatedExtension, patient.Phone.Extension);
+                Assert.Equal(initialPhoneType, patient.Phone.Type);
             }
             // cleanup
             using (var session = SessionFactory.CreateSession())

--- a/src/RedArrow.Argo.Client.Tests/Json/JsonDiffTests.cs
+++ b/src/RedArrow.Argo.Client.Tests/Json/JsonDiffTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+using Ploeh.AutoFixture.Xunit2;
+using RedArrow.Argo.Client.Json;
+using System.Linq;
+using Xunit;
+
+namespace RedArrow.Argo.Client.Tests.Json
+{
+    public class JsonDiffTests
+    {
+        [Theory, AutoData]
+        public void ReducePatch__Given_AllEqual__Then_Null(TestJsonObject obj)
+        {
+            // Assemble
+            var original = JObject.FromObject(obj);
+            var update = JObject.FromObject(obj);
+            var subject = new JsonDiff();
+
+            // Act
+            var result = subject.ReducePatch(original, update);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Theory, AutoData]
+        public void ReducePatch__Given_SinglePropertyNotEqual__Then_PatchProperty(TestJsonObject obj)
+        {
+            // Assemble
+            var original = JObject.FromObject(obj);
+            obj.String = "Updated Value";
+            var update = JObject.FromObject(obj);
+            var subject = new JsonDiff();
+            
+            // Act
+            var result = (JObject)subject.ReducePatch(original, update);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(obj.String, result["String"].Value<string>());
+            // Other properties should not need patching
+            Assert.Single(result);
+        }
+
+        [Theory, AutoData]
+        public void ReducePatch__Given_ChildPropertyNotEqual__Then_PatchProperty(TestJsonObject obj)
+        {
+            // Assemble
+            var original = JObject.FromObject(obj);
+            obj.Child.String = "Updated Value";
+            var update = JObject.FromObject(obj);
+            var subject = new JsonDiff();
+
+            // Act
+            var result = (JObject) subject.ReducePatch(original, update);
+
+            // Assert
+            Assert.NotNull(result);
+            // Values should be targeted
+            Assert.Equal(obj.Child.String, result[nameof(obj.Child)]["String"].Value<string>());
+            // Other properties should not need patching
+            Assert.Single(result);
+        }
+
+        [Theory, AutoData]
+        public void ReducePatch__Given_ArrayPropertyNotEqual__Then_PatchEntireArray(TestJsonObject obj)
+        {
+            // Assemble
+            var original = JObject.FromObject(obj);
+            obj.OtherChildren.First().String = "Updated Value";
+            var update = JObject.FromObject(obj);
+            var subject = new JsonDiff();
+
+            // Act
+            var result = (JObject)subject.ReducePatch(original, update);
+
+            // Assert
+            Assert.NotNull(result);
+
+            // All values should be included in array patch
+            Assert.Equal(obj.OtherChildren.Count, result[nameof(obj.OtherChildren)].Count());
+            var otherChildObj = obj.OtherChildren.First();
+            var otherChildJson = result[nameof(obj.OtherChildren)][0];
+            Assert.Equal(otherChildObj.String, otherChildJson["String"].Value<string>());
+            Assert.Equal(otherChildObj.Guid, otherChildJson["Guid"].Value<Guid>());
+            Assert.Equal(otherChildObj.Int, otherChildJson["Int"].Value<int>());
+            Assert.Equal(otherChildObj.Decimal, otherChildJson["Decimal"].Value<decimal>());
+            Assert.Equal(otherChildObj.Double, otherChildJson["Double"].Value<double>());
+            Assert.Equal(otherChildObj.DateTime, otherChildJson["DateTime"].Value<DateTime>());
+            // Other properties should not need patching
+            Assert.Single(result);
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client.Tests/Json/LooseJsonEqualityComparerTests.cs
+++ b/src/RedArrow.Argo.Client.Tests/Json/LooseJsonEqualityComparerTests.cs
@@ -1,0 +1,175 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Ploeh.AutoFixture.Xunit2;
+using RedArrow.Argo.Client.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace RedArrow.Argo.Client.Tests.Json
+{
+    public class LooseJsonEqualityComparerTests
+    {
+        [Theory, AutoData]
+        public void Equals__Given_IsEqual__Then_True(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.True(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_String__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.String = Guid.NewGuid().ToString();
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_Guid__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.Guid = Guid.NewGuid();
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_Decimal__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.Decimal = 999.999m;
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_DateTime__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.DateTime = DateTime.UtcNow;
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_SingleChild__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.Child.Guid = Guid.NewGuid();
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_OneOfChildren__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.OtherChildren.First().String = Guid.NewGuid().ToString();
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_RemovedChildren__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.OtherChildren.Remove(obj.OtherChildren.First());
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+
+        [Theory, AutoData]
+        public void Equals__Given_NotEqual_AddedChildren__Then_False(TestJsonObject obj)
+        {
+            // Assemble
+            var token1 = JObject.FromObject(obj);
+            obj.OtherChildren.Add(new TestJsonObjectChild());
+            var token2 = JObject.Parse(JsonConvert.SerializeObject(obj));
+
+            var subject = new LooseJsonEqualityComparer();
+
+            // Act
+            var result = subject.Equals(token1, token2);
+
+            // Assert
+            Assert.False(result);
+            Assert.False(JToken.DeepEquals(token1, token2));
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client.Tests/Json/TestJsonObject.cs
+++ b/src/RedArrow.Argo.Client.Tests/Json/TestJsonObject.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RedArrow.Argo.Client.Tests.Json
+{
+    public class TestJsonObject
+    {
+        public string Null
+        {
+            get => null;
+            set => value = null;
+        }
+        public string String { get; set; }
+        public Guid Guid { get; set; }
+        public int Int { get; set; }
+        public Decimal Decimal { get; set; }
+        public double Double { get; set; }
+        public byte[] Bytes { get; set; }
+        public DateTime DateTime { get; set; }
+        public TimeSpan TimeSpan { get; set; }
+
+        public TestJsonObjectChild Child { get; set; }
+        public ICollection<TestJsonObjectChild> OtherChildren { get; set; }
+    }
+
+    public class TestJsonObjectChild
+    {
+        public string Null {
+            get => null;
+            set => value = null;
+        }
+        public string String { get; set; }
+        public Guid Guid { get; set; }
+        public int Int { get; set; }
+        public Decimal Decimal { get; set; }
+        public double Double { get; set; }
+        public byte[] Bytes { get; set; }
+        public DateTime DateTime { get; set; }
+        public TimeSpan TimeSpan { get; set; }
+    }
+}

--- a/src/RedArrow.Argo.Client.Tests/RedArrow.Argo.Client.Tests.csproj
+++ b/src/RedArrow.Argo.Client.Tests/RedArrow.Argo.Client.Tests.csproj
@@ -107,6 +107,9 @@
     <Compile Include="Collections\Generic\RemoteGenericBagTests.cs" />
     <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
     <Compile Include="Extensions\SessionExtensions.cs" />
+    <Compile Include="Json\JsonDiffTests.cs" />
+    <Compile Include="Json\LooseJsonEqualityComparerTests.cs" />
+    <Compile Include="Json\TestJsonObject.cs" />
     <Compile Include="Linq\Queryable\OrderByQueryableTests.cs" />
     <Compile Include="Linq\Queryable\SkipQueryableTests.cs" />
     <Compile Include="Linq\Queryable\TakeQueryableTests.cs" />

--- a/src/RedArrow.Argo.Client/Json/JsonDiff.cs
+++ b/src/RedArrow.Argo.Client/Json/JsonDiff.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace RedArrow.Argo.Client.Json
+{
+    public class JsonDiff
+    {
+        private IEqualityComparer<JToken> Comparer { get; }
+        public JsonDiff()
+        {
+            Comparer = new LooseJsonEqualityComparer();
+        }
+        
+        /// <summary>
+        /// Using the update as a template, remove any properties equivalent to the original
+        /// </summary>
+        /// <param name="original"></param>
+        /// <param name="update"></param>
+        /// <returns>The smallest possible patch</returns>
+        public JToken ReducePatch(JToken original, JToken update)
+        {
+            /* Trim any equivalent values from the patch.
+             * We're NOT removing/nulling values that exist in the original resource,
+             * but not in the new resource.  This trim is coarse-grained to avoid
+             * recursion and provide the safest update (in regard to array updates). */
+
+            // if not exists in original and null in model, then remove from patch
+            // if original same as model including nulls, then remove from patch
+            // if exists in original and null in model, then include in patch
+            // if original is different than model, then include in patch
+            if (original == null || original.Type == JTokenType.Null)
+            {
+                // Respond with the full update, or remove from patch
+                return update?.Type == JTokenType.Null ? null : update;
+            }
+            if (update == null || update.Type == JTokenType.Null)
+            {
+                // Original was not null, so we're nulling the value in the patch
+                return JValue.CreateNull();
+            }
+            if (update.Type == JTokenType.Property)
+            {
+                // Do not pass properties, just JObjects
+                throw new ArgumentException($"Cannot diff type {update.Type}");
+            }
+            if (update.Type == JTokenType.Object)
+            {
+                // Create a new object that only contains the differences between the original and update
+                var originalObj = (JObject) original;
+                var patchObject = new JObject();
+                foreach (var updatedProp in ((JObject)update).Properties())
+                {
+                    originalObj.TryGetValue(updatedProp.Name, out var originalPropValue);
+                    var diff = ReducePatch(originalPropValue, updatedProp.Value);
+                    if (diff != null)
+                    {
+                        patchObject.Add(updatedProp.Name, diff);
+                    }
+                }
+                return patchObject.HasValues
+                    ? patchObject
+                    : null;
+            }
+
+            // Arrays and any JValues
+            return Comparer.Equals(original, update)
+                ? null
+                : update;
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client/Json/LooseJsonEqualityComparer.cs
+++ b/src/RedArrow.Argo.Client/Json/LooseJsonEqualityComparer.cs
@@ -1,0 +1,84 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using JTokenType = Newtonsoft.Json.Linq.JTokenType;
+
+namespace RedArrow.Argo.Client.Json
+{
+    internal class LooseJsonEqualityComparer : IEqualityComparer<JToken>
+    {
+        public bool Equals(JToken token1, JToken token2)
+        {
+            /* Cannot use JToken.DeepEquals because a JSON string converted to JToken
+             * will set most JTokenTypes to String while an object converted to JToken will
+             * set JTokenTypes to the most specific type, like Guid, Uri, DateTime
+             * or whatever so the DeepEquals always returns false. */
+            
+            // Null is null
+            if (token1 == null || token1.Type == JTokenType.Null)
+            {
+                return token2 == null || token2.Type == JTokenType.Null;
+            }
+            if (token2 == null || token2.Type == JTokenType.Null)
+            {
+                return false;
+            }
+            
+            if (token1.Type == JTokenType.Object 
+                || token1.Type == JTokenType.Array 
+                || token1.Type == JTokenType.Boolean
+                || token1.Type == JTokenType.Property)
+            {
+                // These types will match in both a string and object that were converted to JTokens
+                if (token1.Type != token2.Type)
+                {
+                    return false;
+                }
+            }
+            else if (token1.Type == JTokenType.Integer || token1.Type == JTokenType.Float)
+            {
+                // If the json value is numeric, then it could be converted to either one of the numberic types
+                if (token2.Type != JTokenType.Integer && token2.Type != JTokenType.Float)
+                {
+                    return false;
+                }
+            }
+            // Else the type is too ambiguous to properly compare, like String and DateTime 
+            //   are identically represented in JSON strings
+
+            if (token1.Type == JTokenType.Array)
+            {
+                var jarray1 = (JArray)token1;
+                var jarray2 = (JArray)token2;
+                return jarray1.Count == jarray2.Count
+                       && token1.Zip(token2, Equals).All(x => x);
+            }
+            if (token1.Type == JTokenType.Object)
+            {
+                var properties1 = ((JObject) token1).Properties().OrderBy(x => x.Name).ToArray();
+                var properties2 = ((JObject) token2).Properties().OrderBy(x => x.Name).ToArray();
+                return properties1.Length == properties2.Length
+                       && properties1.Zip(properties2, Equals).All(x => x);
+            }
+            if (token1.Type == JTokenType.Property)
+            {
+                return Equals(((JProperty) token1).Value, ((JProperty) token2).Value);
+            }
+
+            if (token1.Type == token2.Type)
+            {
+                return token1.Value<object>().Equals(token2.Value<object>());
+            }
+
+            // Avoid weird situations like a DateTime != String for the same value
+            return JsonConvert.SerializeObject(token1) == JsonConvert.SerializeObject(token2);
+        }
+
+        public int GetHashCode(JToken obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
+++ b/src/RedArrow.Argo.Client/RedArrow.Argo.Client.csproj
@@ -98,6 +98,8 @@
     <Compile Include="Exceptions\ArgoException.cs" />
     <Compile Include="Exceptions\ModelNotRegisteredException.cs" />
     <Compile Include="Exceptions\ModelTypeMismatchException.cs" />
+    <Compile Include="Json\JsonDiff.cs" />
+    <Compile Include="Json\LooseJsonEqualityComparer.cs" />
     <Compile Include="Linq\Executors\SingularAttributesExecutor.cs" />
     <Compile Include="Linq\Queryables\OrderByQueryable.cs" />
     <Compile Include="Linq\Queryables\SkipQueryable.cs" />

--- a/src/WovenByFody/Phone.cs
+++ b/src/WovenByFody/Phone.cs
@@ -6,6 +6,7 @@ namespace WovenByFody
 {
     public class Phone
     {
+        public string Type { get; set; }
         public string Number { get; set; }
         public string Extension { get; set; }
     }


### PR DESCRIPTION
#93 The previous implementation had checked equality for patches only on the 1st level of properties, which resulted in false positives for nested Meta attributes.  The updated code will deeply check the JSON structure for equality and remove any equivalent properties from the patch.  This should make patches optimally small and no longer send patches for unchanged entities.